### PR TITLE
transfered all expression convenience functions to kindr::minimal namespace

### DIFF
--- a/minkindr_gtsam/include/kindr/minimal/quat-transformation-gtsam.h
+++ b/minkindr_gtsam/include/kindr/minimal/quat-transformation-gtsam.h
@@ -43,7 +43,11 @@ template<> struct traits<kindr::minimal::QuatTransformation> {
     return dimension;
   }
 };  // traits
+} // namespace gtsam
 
+using namespace gtsam;
+namespace kindr {
+namespace minimal {
 ////////////////////////////////////////////////////////////////////////////////
 // Convenience functions to make working with expressions easy and fun!
 
@@ -124,6 +128,7 @@ Expression<kindr::minimal::QuatTransformation> slerp(
     double alpha);
 
 
-}  // namespace gtsam
+}  // namespace minimal
+}  // namespace kindr
 
 #endif // MINKINDR_QUAT_TRANSFORMATION_GTSAM_H

--- a/minkindr_gtsam/include/kindr/minimal/quat-transformation-gtsam.h
+++ b/minkindr_gtsam/include/kindr/minimal/quat-transformation-gtsam.h
@@ -45,7 +45,6 @@ template<> struct traits<kindr::minimal::QuatTransformation> {
 };  // traits
 } // namespace gtsam
 
-using namespace gtsam;
 namespace kindr {
 namespace minimal {
 ////////////////////////////////////////////////////////////////////////////////
@@ -57,74 +56,74 @@ namespace minimal {
 /// Expression<Eigen::Vector3d> Tp = T * p;
 /// instead of
 /// Expression<Eigen::Vector3d> Tp = Expression<Eigen::Vector3d>(&transform_point, T, p);
-Expression<Eigen::Vector3d>
-operator*(const Expression<kindr::minimal::QuatTransformation>& T,
-          const Expression<Eigen::Vector3d>& p);
+gtsam::Expression<Eigen::Vector3d>
+operator*(const gtsam::Expression<kindr::minimal::QuatTransformation>& T,
+          const gtsam::Expression<Eigen::Vector3d>& p);
 
 /// \brief Transform a point.
-Expression<Eigen::Vector3d>
-transform(const Expression<kindr::minimal::QuatTransformation>& T,
-          const Expression<Eigen::Vector3d>& p);
+gtsam::Expression<Eigen::Vector3d>
+transform(const gtsam::Expression<kindr::minimal::QuatTransformation>& T,
+          const gtsam::Expression<Eigen::Vector3d>& p);
 
 /// \brief Build a transformation expression from a rotation expression and a
 /// point expression.
-Expression<kindr::minimal::QuatTransformation> transformationFromComponents(
-    const Expression<kindr::minimal::RotationQuaternion>& C_A_B,
-    const Expression<Eigen::Vector3d>& A_t_B);
+gtsam::Expression<kindr::minimal::QuatTransformation> transformationFromComponents(
+    const gtsam::Expression<kindr::minimal::RotationQuaternion>& C_A_B,
+    const gtsam::Expression<Eigen::Vector3d>& A_t_B);
 
 /// \brief Recover the rotation part of a transformation.
-Expression<kindr::minimal::RotationQuaternion> rotationFromTransformation(
-    const Expression<kindr::minimal::QuatTransformation>& T);
+gtsam::Expression<kindr::minimal::RotationQuaternion> rotationFromTransformation(
+    const gtsam::Expression<kindr::minimal::QuatTransformation>& T);
 
 /// \brief Recover the translation part of a transformation.
-Expression<Eigen::Vector3d> translationFromTransformation(
-    const Expression<kindr::minimal::QuatTransformation>& T);
+gtsam::Expression<Eigen::Vector3d> translationFromTransformation(
+    const gtsam::Expression<kindr::minimal::QuatTransformation>& T);
 
 /// \brief Transform a point by the inverse of a transformation.
-Expression<Eigen::Vector3d> inverseTransform(
-    const Expression<kindr::minimal::QuatTransformation>& T,
-    const Expression<Eigen::Vector3d>& p);
+gtsam::Expression<Eigen::Vector3d> inverseTransform(
+    const gtsam::Expression<kindr::minimal::QuatTransformation>& T,
+    const gtsam::Expression<Eigen::Vector3d>& p);
 
 /// \brief Invert a transformation.
-Expression<kindr::minimal::QuatTransformation> inverse(
-    const Expression<kindr::minimal::QuatTransformation>& T);
+gtsam::Expression<kindr::minimal::QuatTransformation> inverse(
+    const gtsam::Expression<kindr::minimal::QuatTransformation>& T);
 
 /// \brief Compose two transformations.
-Expression<kindr::minimal::QuatTransformation> compose(
-    const Expression<kindr::minimal::QuatTransformation>& T1,
-    const Expression<kindr::minimal::QuatTransformation>& T2);
+gtsam::Expression<kindr::minimal::QuatTransformation> compose(
+    const gtsam::Expression<kindr::minimal::QuatTransformation>& T1,
+    const gtsam::Expression<kindr::minimal::QuatTransformation>& T2);
 
 /// \brief Compose two transformations.
-inline Expression<kindr::minimal::QuatTransformation> operator*(
-    const Expression<kindr::minimal::QuatTransformation>& T1,
-    const Expression<kindr::minimal::QuatTransformation>& T2) {
+inline gtsam::Expression<kindr::minimal::QuatTransformation> operator*(
+    const gtsam::Expression<kindr::minimal::QuatTransformation>& T1,
+    const gtsam::Expression<kindr::minimal::QuatTransformation>& T2) {
   return compose(T1,T2);
 }
 
 /// \brief Compose two transformations as inv(T1)*T2.
-Expression<kindr::minimal::QuatTransformation> invertAndCompose(
-    const Expression<kindr::minimal::QuatTransformation>& T1,
-    const Expression<kindr::minimal::QuatTransformation>& T2);
+gtsam::Expression<kindr::minimal::QuatTransformation> invertAndCompose(
+    const gtsam::Expression<kindr::minimal::QuatTransformation>& T1,
+    const gtsam::Expression<kindr::minimal::QuatTransformation>& T2);
 
 /// \brief Recover the matrix log of R^3 x SO3
-Expression<Vector6> log(const Expression<kindr::minimal::QuatTransformation>& T);
+gtsam::Expression<gtsam::Vector6> log(const gtsam::Expression<kindr::minimal::QuatTransformation>& T);
 
 /// \brief The exponential map of R^3 x SO3
-Expression<kindr::minimal::QuatTransformation> exp(const Expression<Vector6>& params);
+gtsam::Expression<kindr::minimal::QuatTransformation> exp(const gtsam::Expression<gtsam::Vector6>& params);
 
 /// \brief Recover the matrix log of the rotation part of the transformation.
-Expression<Eigen::Vector3d> rotationLog(
-    const Expression<kindr::minimal::QuatTransformation>& T);
+gtsam::Expression<Eigen::Vector3d> rotationLog(
+    const gtsam::Expression<kindr::minimal::QuatTransformation>& T);
 
 /// \brief Recover the matrix log of the translation part of the transformation.
-inline Expression<Eigen::Vector3d> translationLog(
-    const Expression<kindr::minimal::QuatTransformation>& T) {
+inline gtsam::Expression<Eigen::Vector3d> translationLog(
+    const gtsam::Expression<kindr::minimal::QuatTransformation>& T) {
   return translationFromTransformation(T);
 }
 
-Expression<kindr::minimal::QuatTransformation> slerp(
-    const Expression<kindr::minimal::QuatTransformation>& T0,
-    const Expression<kindr::minimal::QuatTransformation>& T1,
+gtsam::Expression<kindr::minimal::QuatTransformation> slerp(
+    const gtsam::Expression<kindr::minimal::QuatTransformation>& T0,
+    const gtsam::Expression<kindr::minimal::QuatTransformation>& T1,
     double alpha);
 
 

--- a/minkindr_gtsam/include/kindr/minimal/rotation-quaternion-gtsam.h
+++ b/minkindr_gtsam/include/kindr/minimal/rotation-quaternion-gtsam.h
@@ -48,20 +48,19 @@ template<> struct traits<kindr::minimal::RotationQuaternion> {
 };  // traits
 } //namespace gtsam
 
-using namespace gtsam;
 namespace kindr {
 namespace minimal {
 ////////////////////////////////////////////////////////////////////////////////
 // Convenience functions to make working with expressions easy and fun!
 
 /// \brief Invert a rotation quaternion expression.
-Expression<kindr::minimal::RotationQuaternion> invert(
-    const Expression<kindr::minimal::RotationQuaternion>& q);
+gtsam::Expression<kindr::minimal::RotationQuaternion> invert(
+    const gtsam::Expression<kindr::minimal::RotationQuaternion>& q);
 
 /// \brief Compose two quaternion expressions.
-Expression<kindr::minimal::RotationQuaternion>
-operator*(const Expression<kindr::minimal::RotationQuaternion>& C1,
-          const Expression<kindr::minimal::RotationQuaternion>& C2);
+gtsam::Expression<kindr::minimal::RotationQuaternion>
+operator*(const gtsam::Expression<kindr::minimal::RotationQuaternion>& C1,
+          const gtsam::Expression<kindr::minimal::RotationQuaternion>& C2);
 
 /// \brief Rotate a point.
 ///
@@ -85,7 +84,7 @@ gtsam::Expression<Eigen::Vector3d> inverseRotate(
 
 /// \brief Expose the rotation log and Jacobian.
 Eigen::Vector3d rotationLogImplementation(const kindr::minimal::RotationQuaternion& C,
-                                          OptionalJacobian<3, 3> JC);
+                                          gtsam::OptionalJacobian<3, 3> JC);
 
 /// \brief Compute the matrix log of SO3.
 gtsam::Expression<Eigen::Vector3d> log(
@@ -93,7 +92,7 @@ gtsam::Expression<Eigen::Vector3d> log(
 
 /// \brief Expose the rotation log and Jacobian.
 kindr::minimal::RotationQuaternion rotationExpImplementation(const Eigen::Vector3d& p,
-                                                             OptionalJacobian<3, 3> Jp);
+                                                             gtsam::OptionalJacobian<3, 3> Jp);
 
 /// \brief Compute the matrix log of SO3.
 gtsam::Expression<kindr::minimal::RotationQuaternion> exp(

--- a/minkindr_gtsam/include/kindr/minimal/rotation-quaternion-gtsam.h
+++ b/minkindr_gtsam/include/kindr/minimal/rotation-quaternion-gtsam.h
@@ -46,7 +46,11 @@ template<> struct traits<kindr::minimal::RotationQuaternion> {
     return dimension;
   }
 };  // traits
+} //namespace gtsam
 
+using namespace gtsam;
+namespace kindr {
+namespace minimal {
 ////////////////////////////////////////////////////////////////////////////////
 // Convenience functions to make working with expressions easy and fun!
 
@@ -94,6 +98,8 @@ kindr::minimal::RotationQuaternion rotationExpImplementation(const Eigen::Vector
 /// \brief Compute the matrix log of SO3.
 gtsam::Expression<kindr::minimal::RotationQuaternion> exp(
     const gtsam::Expression<Eigen::Vector3d>& C);
-}  // namespace gtsam
+
+}  // namespace minimal
+}  // namespace kindr
 
 #endif // MINKINDR_QUATERNION_GTSAM_H

--- a/minkindr_gtsam/src/quat-transformation-gtsam.cc
+++ b/minkindr_gtsam/src/quat-transformation-gtsam.cc
@@ -1,5 +1,6 @@
 #include <kindr/minimal/quat-transformation-gtsam.h>
-namespace gtsam {
+namespace kindr {
+namespace minimal {
 Eigen::Vector3d transform_point(const kindr::minimal::QuatTransformation& T,
                                 const Eigen::Vector3d& p,
                                 OptionalJacobian<3, 6> HT,
@@ -252,4 +253,6 @@ Expression<kindr::minimal::QuatTransformation> exp(const Expression<Vector6>& pa
   return Expression<kindr::minimal::QuatTransformation>(
       &transformationExpImplementation, params);
 }
-} // namespace gtsam
+
+}  // namespace minimal
+}  // namespace kindr

--- a/minkindr_gtsam/src/quat-transformation-gtsam.cc
+++ b/minkindr_gtsam/src/quat-transformation-gtsam.cc
@@ -1,4 +1,7 @@
 #include <kindr/minimal/quat-transformation-gtsam.h>
+
+using namespace gtsam;
+
 namespace kindr {
 namespace minimal {
 Eigen::Vector3d transform_point(const kindr::minimal::QuatTransformation& T,

--- a/minkindr_gtsam/src/rotation-quaternion-gtsam.cc
+++ b/minkindr_gtsam/src/rotation-quaternion-gtsam.cc
@@ -1,5 +1,7 @@
 #include <kindr/minimal/rotation-quaternion-gtsam.h>
 
+using namespace gtsam;
+
 namespace kindr {
 namespace minimal {
 Eigen::Vector3d rotate_point(

--- a/minkindr_gtsam/src/rotation-quaternion-gtsam.cc
+++ b/minkindr_gtsam/src/rotation-quaternion-gtsam.cc
@@ -1,7 +1,7 @@
 #include <kindr/minimal/rotation-quaternion-gtsam.h>
 
-namespace gtsam {
-
+namespace kindr {
+namespace minimal {
 Eigen::Vector3d rotate_point(
     const kindr::minimal::RotationQuaternion& C, const Eigen::Vector3d& p,
     OptionalJacobian<3, 3> HC, OptionalJacobian<3, 3> Hp) {
@@ -131,4 +131,5 @@ Expression<kindr::minimal::RotationQuaternion> exp(
   return Expression<kindr::minimal::RotationQuaternion>(&rotationExpImplementation, C);
 }
 
-}  // namespace gtsam
+}  // namespace minimal
+}  // namespace kindr

--- a/minkindr_gtsam/test/test_minkindr-gtsam.cc
+++ b/minkindr_gtsam/test/test_minkindr-gtsam.cc
@@ -234,7 +234,7 @@ TEST(MinkindrGtsamTests, testSO3Exp) {
   values.insert(1, pval);
 
   Expression<Eigen::Vector3d> p(1);
-  Expression<Quaternion> C = exp(p);
+  Expression<Quaternion> C = kindr::minimal::exp(p);
 
   const double fd_step = 1e-9;
   const double tolerance = 1e-6;
@@ -252,7 +252,7 @@ TEST(MinkindrGtsamTests, testSE3Exp) {
   values.insert(1, pval);
 
   Expression<gtsam::Vector6> p(1);
-  Expression<Transformation> T = exp(p);
+  Expression<Transformation> T = kindr::minimal::exp(p);
 
   const double fd_step = 1e-9;
   const double tolerance = 1e-6;


### PR DESCRIPTION
Was we declared the `exp()` function in the gtsam namespace, it was conflicting internally with gtsam. My solution to this was to put these convenience functions into kindr::minimal namespace instead. I think it makes sense to have these functions belong to minkindr, not gtsam.

@mikebosse @gawela  is there a better way of solving this? Thanks!