### PR TITLE
QtCreator compatibility: Headers in CMakeLists.txt

### DIFF
--- a/minkindr/CMakeLists.txt
+++ b/minkindr/CMakeLists.txt
@@ -13,6 +13,18 @@ catkin_add_gtest(${PROJECT_NAME}_tests
   test/test-transformation.cc
 )
 
+# Add all files to show up in QtCreator.
+add_custom_target(${PROJECT_NAME} SOURCES
+  include/kindr/minimal/angle-axis.h
+  include/kindr/minimal/common.h
+  include/kindr/minimal/position.h
+  include/kindr/minimal/quat-transformation.h
+  include/kindr/minimal/rotation-quaternion.h
+  include/kindr/minimal/implementation/angle-axis-inl.h
+  include/kindr/minimal/implementation/quat-transformation-inl.h
+  include/kindr/minimal/implementation/rotation-quaternion-inl.h
+)
+
 target_link_libraries(${PROJECT_NAME}_tests ${catkin_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 cs_install()

--- a/minkindr_gtsam/CMakeLists.txt
+++ b/minkindr_gtsam/CMakeLists.txt
@@ -7,6 +7,12 @@ catkin_simple(ALL_DEPS_REQUIRED)
 cs_add_library(${PROJECT_NAME}
 	src/rotation-quaternion-gtsam.cc
 	src/quat-transformation-gtsam.cc
+	include/kindr/minimal/common-gtsam.h
+	include/kindr/minimal/cubic-hermite-quaternion-gtsam.h
+	include/kindr/minimal/quat-transformation-gtsam.h
+	include/kindr/minimal/rotation-quaternion-gtsam.h
+	include/kindr/minimal/testing-gtsam.h
+	include/kindr/minimal/implementation/common-gtsam-inl.h
 )
 
 # cs_add_executable(${PROJECT_NAME} src/main.cc)


### PR DESCRIPTION
Using QtCreator requires that we add all header files to the CMakeLists.txt as the CMakeListst.txt is QtCreator's main project file.
