### PR TITLE
fix QuatTransformationTemplate<Scalar>::inverse(): use templated version

### DIFF
--- a/minkindr/include/kindr/minimal/implementation/quat-transformation-inl.h
+++ b/minkindr/include/kindr/minimal/implementation/quat-transformation-inl.h
@@ -202,7 +202,7 @@ QuatTransformationTemplate<Scalar>::inverseTransform4(
 template<typename Scalar>
 QuatTransformationTemplate<Scalar>
 QuatTransformationTemplate<Scalar>::inverse() const {
-  return QuatTransformation(q_A_B_.inverse(), -q_A_B_.inverseRotate(A_t_A_B_));
+  return QuatTransformationTemplate<Scalar>(q_A_B_.inverse(), -q_A_B_.inverseRotate(A_t_A_B_));
 }
 
 template<typename Scalar>


### PR DESCRIPTION
minor fix to make it compile with floats.