### PR TITLE
isValidRotationMatrix: use lower accuracy requirements for floats

### DIFF
--- a/minkindr/include/kindr/minimal/implementation/rotation-quaternion-inl.h
+++ b/minkindr/include/kindr/minimal/implementation/rotation-quaternion-inl.h
@@ -32,6 +32,20 @@
 namespace kindr {
 namespace minimal {
 
+template<typename Scalar>
+struct EPS {
+  static constexpr Scalar value();
+};
+template<>
+struct EPS<double> {
+  static constexpr double value() { return 1.0e-8; }
+};
+template<>
+struct EPS<float> {
+  static constexpr float value() { return 1.0e-5f; }
+};
+
+
 /// \brief initialize to identity
 template<typename Scalar>
 RotationQuaternionTemplate<Scalar>::RotationQuaternionTemplate()
@@ -495,8 +509,7 @@ RotationQuaternionTemplate<Scalar>::log() const {
 template<typename Scalar>
 bool RotationQuaternionTemplate<Scalar>::isValidRotationMatrix(
     const RotationMatrix& matrix) {
-  constexpr Scalar kThreshold = static_cast<Scalar>(1.0e-8);
-  return isValidRotationMatrix(matrix, kThreshold);
+  return isValidRotationMatrix(matrix, EPS<Scalar>::value());
 }
 
 template<typename Scalar>


### PR DESCRIPTION
If the library is used with template type Scalar=float, the 1.0e-8 for isValidRotationMatrix is too low and cannot be satisfied. This increases the value to 1.0e-5f for floats but keeps the old value for double.