### PR TITLE
So a JPL representation can be obtained of a transformation.

### DIFF
--- a/minkindr/include/kindr/minimal/implementation/quat-transformation-inl.h
+++ b/minkindr/include/kindr/minimal/implementation/quat-transformation-inl.h
@@ -141,6 +141,19 @@ QuatTransformationTemplate<Scalar>::asVector() const {
 }
 
 template<typename Scalar>
+Eigen::Matrix<Scalar, 7, 1>
+QuatTransformationTemplate<Scalar>::asHamiltonianVector() const{
+  return asVector();
+}
+
+template<typename Scalar>
+Eigen::Matrix<Scalar, 7, 1>
+QuatTransformationTemplate<Scalar>::asJPLVector() const{
+  return (Eigen::Matrix<Scalar, 7, 1>() <<
+      q_A_B_.x(), q_A_B_.y(), q_A_B_.z(), q_A_B_.w(), A_t_A_B_).finished();
+}
+
+template<typename Scalar>
 typename QuatTransformationTemplate<Scalar>::RotationMatrix
 QuatTransformationTemplate<Scalar>::getRotationMatrix() const {
   return q_A_B_.getRotationMatrix();

--- a/minkindr/include/kindr/minimal/quat-transformation.h
+++ b/minkindr/include/kindr/minimal/quat-transformation.h
@@ -116,6 +116,14 @@ class QuatTransformationTemplate {
   ///  [w x y z, x y z]
   Eigen::Matrix<Scalar, 7, 1> asVector() const;
 
+  /// \brief get the quaternion of rotation and the position as a vector.
+  /// [w x y z, x y z]
+  Eigen::Matrix<Scalar, 7, 1> asHamiltonianVector() const;
+
+  // \brief get the quaternion of rotation and the position as a vector.
+  /// [x y z w, x y z]
+  Eigen::Matrix<Scalar, 7, 1> asJPLVector() const;
+
   /// \brief compose two transformations.
   QuatTransformationTemplate<Scalar> operator*(
       const QuatTransformationTemplate<Scalar>& rhs) const;


### PR DESCRIPTION
Since multiagentmapping and possibly many other program uses JPL notation it is convenient to have a function that can return the transformation vector in JPL notation.