### PR TITLE
changed angle axis operation to not require doubles

### DIFF
--- a/minkindr/include/kindr/minimal/implementation/rotation-quaternion-inl.h
+++ b/minkindr/include/kindr/minimal/implementation/rotation-quaternion-inl.h
@@ -425,13 +425,13 @@ RotationQuaternionTemplate<Scalar>::getRotationMatrix() const {
 template<typename Scalar>
 Scalar RotationQuaternionTemplate<Scalar>::getDisparityAngle(
     const RotationQuaternionTemplate<Scalar>& rhs) const{
-  return AngleAxis(rhs * this->inverse()).getUnique().angle();
+  return AngleAxisTemplate<Scalar>(rhs * this->inverse()).getUnique().angle();
 }
 
 template<typename Scalar>
 Scalar RotationQuaternionTemplate<Scalar>::getDisparityAngle(
     const AngleAxisTemplate<Scalar>& rhs) const{
-  return AngleAxis(rhs * this->inverse()).getUnique().angle();
+  return AngleAxisTemplate<Scalar>(rhs * this->inverse()).getUnique().angle();
 }
 
 template<typename Scalar>


### PR DESCRIPTION
The get DisparityAngle functions previously used the non-templated version of AngleAxis meaning they would work for doubles but throw an error on floats.