### PR TITLE
ceres jet type compatibility

### DIFF
--- a/minkindr/include/kindr/minimal/implementation/rotation-quaternion-inl.h
+++ b/minkindr/include/kindr/minimal/implementation/rotation-quaternion-inl.h
@@ -33,8 +33,10 @@ namespace minimal {
 
 template <typename Scalar>
 struct EPS {
-  static constexpr Scalar value();
-  static constexpr Scalar normalization_value();
+  static constexpr Scalar value() { return static_cast<Scalar>(1.0e-5); }
+  static constexpr Scalar normalization_value() {
+    return static_cast<Scalar>(1.0e-4);
+  }
 };
 template <>
 struct EPS<double> {
@@ -407,8 +409,9 @@ RotationQuaternionTemplate<Scalar>::operator*(
 
   // check if the multiplication has resulted in the quaternion no longer being
   // approximately normalized.
-  if (std::abs(result.squaredNorm() - static_cast<Scalar>(1.0)) >
-      EPS<Scalar>::normalization_value()) {
+  Scalar signed_norm_diff = result.squaredNorm() - static_cast<Scalar>(1.0);
+  if ((signed_norm_diff > EPS<Scalar>::normalization_value()) ||
+      (signed_norm_diff < - EPS<Scalar>::normalization_value())) {
     // renormalize
     result.normalize();
   }

--- a/minkindr/include/kindr/minimal/implementation/rotation-quaternion-inl.h
+++ b/minkindr/include/kindr/minimal/implementation/rotation-quaternion-inl.h
@@ -407,9 +407,12 @@ template<typename Scalar>
 RotationQuaternionTemplate<Scalar>
 RotationQuaternionTemplate<Scalar>::operator*(
     const RotationQuaternionTemplate<Scalar>& rhs) const {
+  CHECK(!std::is_arithmetic<Scalar>::value) << "Please provide a specialized "
+      "function for arithmetic types. This function is only a workaround for "
+      "non-arithmetic types.";
   Implementation result = q_A_B_ * rhs.q_A_B_;
 
-  // check if the multiplication has resulted in the quaternion no longer being
+  // Check if the multiplication has resulted in the quaternion no longer being
   // approximately normalized.
   // Cover the case of non-arithmetic types that may not provide an
   // implementation of std::abs.
@@ -427,14 +430,7 @@ RotationQuaternionTemplate<float>
 RotationQuaternionTemplate<float>::operator*(
     const RotationQuaternionTemplate<float>& rhs) const {
   Implementation result = q_A_B_ * rhs.q_A_B_;
-
-  // check if the multiplication has resulted in the quaternion no longer being
-  // approximately normalized.
-  if (std::abs(result.squaredNorm() - 1.0f) >
-      EPS<float>::normalization_value()) {
-    // renormalize
-    result.normalize();
-  }
+  normalizationHelper(&result);
   return RotationQuaternionTemplate<float>(result);
 }
 
@@ -443,14 +439,7 @@ RotationQuaternionTemplate<double>
 RotationQuaternionTemplate<double>::operator*(
     const RotationQuaternionTemplate<double>& rhs) const {
   Implementation result = q_A_B_ * rhs.q_A_B_;
-
-  // check if the multiplication has resulted in the quaternion no longer being
-  // approximately normalized.
-  if (std::abs(result.squaredNorm() - 1.0f) >
-      EPS<double>::normalization_value()) {
-    // renormalize
-    result.normalize();
-  }
+  normalizationHelper(&result);
   return RotationQuaternionTemplate<double>(result);
 }
 
@@ -587,6 +576,18 @@ RotationQuaternionTemplate<Scalar>::cast() const {
   // renormalization needed to allow casting to increased precision
   return RotationQuaternionTemplate<ScalarAfterCast>::constructAndRenormalize(
       getRotationMatrix().template cast<ScalarAfterCast>());
+}
+
+template <typename Scalar>
+void RotationQuaternionTemplate<Scalar>::normalizationHelper(Implementation* quaternion) const {
+  CHECK_NOTNULL(quaternion);
+  // check if the multiplication has resulted in the quaternion no longer being
+  // approximately normalized.
+  if (std::abs(quaternion->squaredNorm() - static_cast<Scalar>(1)) >
+      EPS<Scalar>::normalization_value()) {
+    // renormalize
+    quaternion->normalize();
+  }
 }
 
 } // namespace minimal

--- a/minkindr/include/kindr/minimal/implementation/rotation-quaternion-inl.h
+++ b/minkindr/include/kindr/minimal/implementation/rotation-quaternion-inl.h
@@ -408,8 +408,8 @@ RotationQuaternionTemplate<Scalar>
 RotationQuaternionTemplate<Scalar>::operator*(
     const RotationQuaternionTemplate<Scalar>& rhs) const {
   CHECK(!std::is_arithmetic<Scalar>::value) << "Please provide a specialized "
-      "function for arithmetic types. This function is only a workaround for "
-      "non-arithmetic types.";
+      "function for this specific arithmetic type. This function is only a "
+      "workaround for non-arithmetic types.";
   Implementation result = q_A_B_ * rhs.q_A_B_;
 
   // Check if the multiplication has resulted in the quaternion no longer being

--- a/minkindr/include/kindr/minimal/implementation/rotation-quaternion-inl.h
+++ b/minkindr/include/kindr/minimal/implementation/rotation-quaternion-inl.h
@@ -25,8 +25,6 @@
 #ifndef KINDR_MIN_ROTATION_QUATERNION_INL_H_
 #define KINDR_MIN_ROTATION_QUATERNION_INL_H_
 
-#include <type_traits>
-
 #include <glog/logging.h>
 #include <kindr/minimal/rotation-quaternion.h>
 #include <kindr/minimal/angle-axis.h>

--- a/minkindr/include/kindr/minimal/implementation/rotation-quaternion-inl.h
+++ b/minkindr/include/kindr/minimal/implementation/rotation-quaternion-inl.h
@@ -24,6 +24,9 @@
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef KINDR_MIN_ROTATION_QUATERNION_INL_H_
 #define KINDR_MIN_ROTATION_QUATERNION_INL_H_
+
+#include <type_traits>
+
 #include <glog/logging.h>
 #include <kindr/minimal/rotation-quaternion.h>
 #include <kindr/minimal/angle-axis.h>
@@ -48,7 +51,6 @@ struct EPS<float> {
   static constexpr float value() { return 1.0e-5f; }
   static constexpr float normalization_value() { return 1.0e-4f; }
 };
-
 
 /// \brief initialize to identity
 template<typename Scalar>
@@ -409,6 +411,8 @@ RotationQuaternionTemplate<Scalar>::operator*(
 
   // check if the multiplication has resulted in the quaternion no longer being
   // approximately normalized.
+  // Cover the case of non-arithmetic types that may not provide an
+  // implementation of std::abs.
   Scalar signed_norm_diff = result.squaredNorm() - static_cast<Scalar>(1.0);
   if ((signed_norm_diff > EPS<Scalar>::normalization_value()) ||
       (signed_norm_diff < - EPS<Scalar>::normalization_value())) {
@@ -416,6 +420,38 @@ RotationQuaternionTemplate<Scalar>::operator*(
     result.normalize();
   }
   return RotationQuaternionTemplate<Scalar>(result);
+}
+
+template<> inline
+RotationQuaternionTemplate<float>
+RotationQuaternionTemplate<float>::operator*(
+    const RotationQuaternionTemplate<float>& rhs) const {
+  Implementation result = q_A_B_ * rhs.q_A_B_;
+
+  // check if the multiplication has resulted in the quaternion no longer being
+  // approximately normalized.
+  if (std::abs(result.squaredNorm() - 1.0f) >
+      EPS<float>::normalization_value()) {
+    // renormalize
+    result.normalize();
+  }
+  return RotationQuaternionTemplate<float>(result);
+}
+
+template<> inline
+RotationQuaternionTemplate<double>
+RotationQuaternionTemplate<double>::operator*(
+    const RotationQuaternionTemplate<double>& rhs) const {
+  Implementation result = q_A_B_ * rhs.q_A_B_;
+
+  // check if the multiplication has resulted in the quaternion no longer being
+  // approximately normalized.
+  if (std::abs(result.squaredNorm() - 1.0f) >
+      EPS<double>::normalization_value()) {
+    // renormalize
+    result.normalize();
+  }
+  return RotationQuaternionTemplate<double>(result);
 }
 
 template<typename Scalar>

--- a/minkindr/include/kindr/minimal/rotation-quaternion.h
+++ b/minkindr/include/kindr/minimal/rotation-quaternion.h
@@ -218,6 +218,8 @@ class RotationQuaternionTemplate {
   RotationQuaternionTemplate<ScalarAfterCast> cast() const;
 
  private:
+  void normalizationHelper(Implementation* quaternion) const;
+
   Implementation q_A_B_;
 };
 


### PR DESCRIPTION
Since [this](https://github.com/ethz-asl/minkindr/pull/52/files) PR, we cannot use minkindr with ceres jet types anymore. In fact, I am suprised that it has ever worked. This is not a proper solution but it works for us at the moment. I am open to suggestions on how to do this in a better way.