### PR TITLE
Adding printing to transformation2D.

### DIFF
--- a/minkindr/include/kindr/minimal/angle-axis.h
+++ b/minkindr/include/kindr/minimal/angle-axis.h
@@ -25,6 +25,8 @@
 #ifndef KINDR_MIN_ROTATION_ANGLE_AXIS_H_
 #define KINDR_MIN_ROTATION_ANGLE_AXIS_H_
 
+#include <ostream>
+
 #include <Eigen/Dense>
 
 namespace kindr {

--- a/minkindr/include/kindr/minimal/implementation/transform-2d-inl.h
+++ b/minkindr/include/kindr/minimal/implementation/transform-2d-inl.h
@@ -136,6 +136,13 @@ bool Transformation2DTemplate<Scalar>::operator!=(
 }
 
 template <typename Scalar>
+std::ostream & operator<<(std::ostream & out,
+                          const Transformation2DTemplate<Scalar>& rhs) {
+  out << rhs.asVector().transpose();
+  return out;
+}
+
+template <typename Scalar>
 template <typename ScalarAfterCast>
 Transformation2DTemplate<ScalarAfterCast>
 Transformation2DTemplate<Scalar>::cast() const {

--- a/minkindr/include/kindr/minimal/implementation/transform-2d-inl.h
+++ b/minkindr/include/kindr/minimal/implementation/transform-2d-inl.h
@@ -138,7 +138,8 @@ bool Transformation2DTemplate<Scalar>::operator!=(
 template <typename Scalar>
 std::ostream & operator<<(std::ostream & out,
                           const Transformation2DTemplate<Scalar>& rhs) {
-  out << rhs.asVector().transpose();
+   out << "[" <<rhs.getRotation().angle() << ", ["
+       << rhs.getPosition().transpose() << "]]";
   return out;
 }
 

--- a/minkindr/include/kindr/minimal/implementation/transform-2d-inl.h
+++ b/minkindr/include/kindr/minimal/implementation/transform-2d-inl.h
@@ -138,8 +138,8 @@ bool Transformation2DTemplate<Scalar>::operator!=(
 template <typename Scalar>
 std::ostream & operator<<(std::ostream & out,
                           const Transformation2DTemplate<Scalar>& rhs) {
-   out << "[" <<rhs.getRotation().angle() << ", ["
-       << rhs.getPosition().transpose() << "]]";
+  out << "[" <<rhs.getRotation().angle() << ", ["
+      << rhs.getPosition().transpose() << "]]";
   return out;
 }
 

--- a/minkindr/include/kindr/minimal/quat-sim-transform.h
+++ b/minkindr/include/kindr/minimal/quat-sim-transform.h
@@ -3,6 +3,8 @@
 
 #include <Eigen/Dense>
 
+#include <ostream>
+
 #include "kindr/minimal/quat-transformation.h"
 
 namespace kindr {

--- a/minkindr/include/kindr/minimal/quat-sim-transform.h
+++ b/minkindr/include/kindr/minimal/quat-sim-transform.h
@@ -1,9 +1,9 @@
 #ifndef KINDR_MINIMAL_QUAT_SIM_TRANSFORM_H_
 #define KINDR_MINIMAL_QUAT_SIM_TRANSFORM_H_
 
-#include <Eigen/Dense>
-
 #include <ostream>
+
+#include <Eigen/Dense>
 
 #include "kindr/minimal/quat-transformation.h"
 

--- a/minkindr/include/kindr/minimal/quat-transformation.h
+++ b/minkindr/include/kindr/minimal/quat-transformation.h
@@ -25,6 +25,8 @@
 #ifndef KINDR_MINIMAL_QUAT_TRANSFORMATION_H_
 #define KINDR_MINIMAL_QUAT_TRANSFORMATION_H_
 
+#include <ostream>
+
 #include <kindr/minimal/rotation-quaternion.h>
 #include <kindr/minimal/position.h>
 

--- a/minkindr/include/kindr/minimal/rotation-quaternion.h
+++ b/minkindr/include/kindr/minimal/rotation-quaternion.h
@@ -25,6 +25,8 @@
 #ifndef KINDR_MIN_ROTATION_QUATERNION_H_
 #define KINDR_MIN_ROTATION_QUATERNION_H_
 
+#include <ostream>
+
 #include <Eigen/Dense>
 
 namespace kindr {

--- a/minkindr/include/kindr/minimal/transform-2d.h
+++ b/minkindr/include/kindr/minimal/transform-2d.h
@@ -1,6 +1,8 @@
 #ifndef KINDR_MINIMAL_TRANSFORM_2D_H_
 #define KINDR_MINIMAL_TRANSFORM_2D_H_
 
+#include <ostream>
+
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 

--- a/minkindr/include/kindr/minimal/transform-2d.h
+++ b/minkindr/include/kindr/minimal/transform-2d.h
@@ -99,6 +99,9 @@ using Position2D = Position2DTemplate<double>;
 using Rotation2D = Rotation2DTemplate<double>;
 using Transformation2D = Transformation2DTemplate<double>;
 
+template<typename Scalar>
+std::ostream & operator<<(std::ostream & out,
+    const Transformation2DTemplate<Scalar>& rhs);
 }  // namespace minimal
 }  // namespace kindr
 

--- a/minkindr/include/kindr/minimal/transform-2d.h
+++ b/minkindr/include/kindr/minimal/transform-2d.h
@@ -102,6 +102,7 @@ using Transformation2D = Transformation2DTemplate<double>;
 template<typename Scalar>
 std::ostream & operator<<(std::ostream & out,
     const Transformation2DTemplate<Scalar>& rhs);
+
 }  // namespace minimal
 }  // namespace kindr
 


### PR DESCRIPTION
Overloaded the `<<` operator with a `Transformation2D` type similar to the other types, to allow simple logging.